### PR TITLE
Fix typo in Sundance article

### DIFF
--- a/writings/five-days-at-sundance.html
+++ b/writings/five-days-at-sundance.html
@@ -115,7 +115,7 @@
             <br><br>
             <b>Abortion Helpline, This is Lisa</b>: 4.5 stars. Documentary short of counselors responding to calls at a Philadelphia abortion hotline. Endless barrage of women calling for financial help to cover abortion costs. Gut-wrenching look at how U.S. legislation bars abortion access for women who need it the most.
             <br><br>
-            <b>Junior Bangers</b>: 5 stars. Documentary short of U.K. boys racing old scrap vehicles. Banger racing is rugged and dangerous. Yet, when it’s 11 year olds racing, there’s a softness to it. Great documentaries transport you into another world as well as the best fantasties and sci-fi flicks do.
+            <b>Junior Bangers</b>: 5 stars. Documentary short of U.K. boys racing old scrap vehicles. Banger racing is rugged and dangerous. Yet, when it’s 11 year olds racing, there’s a softness to it. Great documentaries transport you into another world as well as the best fantasies and sci-fi flicks do.
             <br><br>
             <b>Feels Good Man</b>: 5 stars. Documentary about the rise of “Pepe the Frog”, originally a cartoon character and now a widely shared meme. Told through the eyes of Pepe’s creator, the film raised urgent questions. Who’s responsible for an innocent idea twisted into something grotesque on the internet? What moral obligations do artists have? 
             <br><br>


### PR DESCRIPTION
## Summary
- correct `fantasties` to `fantasies` in Sundance recap

## Testing
- `grep -n fantasies writings/five-days-at-sundance.html`
